### PR TITLE
fix: fixed readme file path in build script

### DIFF
--- a/scripts/create-pkg.js
+++ b/scripts/create-pkg.js
@@ -31,7 +31,7 @@ const finalFileContent = JSON.stringify(destinationPackageContent, null, 4)
 fs.writeFileSync(path.resolve(__dirname, "../dist/package.json"), finalFileContent)
 
 //Copy our readme and license file
-const filesToCopy = ["Readme.md", "LICENSE", "CHANGELOG.md"]
+const filesToCopy = ["README.md", "LICENSE", "CHANGELOG.md"]
 for (let file of filesToCopy) {
     fs.copyFileSync(path.resolve(__dirname, `../${file}`), path.resolve(__dirname, `../dist/${file}`))
 }


### PR DESCRIPTION
Build script didn't work because on Linux machine file system is сase sensitive